### PR TITLE
fix(agent): extract E.164 DID from room name; await room.sid; stabilize Deepgram FR; wire token envs in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,4 +70,6 @@ jobs:
           --set-string secrets.dotenv.ELEVEN_API_KEY='${{ secrets.DOTENV_ELEVEN_API_KEY }}' \
           --set-string secrets.dotenv.LIVEKIT_API_KEY='${{ secrets.DOTENV_LIVEKIT_API_KEY }}' \
           --set-string secrets.dotenv.LIVEKIT_API_SECRET='${{ secrets.DOTENV_LIVEKIT_API_SECRET }}' \
+          --set-string secrets.dotenv.JWT_SECRET='${{ secrets.JWT_SECRET }}' \
+          --set-string secrets.dotenv.VOICE_CONFIG_TOKEN_URL='${{ secrets.VOICE_CONFIG_TOKEN_URL }}' \
             --wait


### PR DESCRIPTION
fix(agent): extract E.164 DID from room name; await room.sid; stabilize Deepgram FR; wire token envs in deploy

- Phone extraction: parse +E.164 anywhere in room name (e.g., Twilio “twilio-+E164-...”) to avoid default config fallback
- Session ID: await room.sid when coroutine; fallback to room.name — removes RuntimeWarning
- STT: set French Deepgram to nova-2-general and align fallbacks to prevent auto-fallback warnings
- CI/CD: pass JWT_SECRET and VOICE_CONFIG_TOKEN_URL to Helm via deploy.yml (secrets.dotenv.*) so prod uses token-based config fetch